### PR TITLE
Add support for default_action in generic template message

### DIFF
--- a/models.go
+++ b/models.go
@@ -172,6 +172,15 @@ func (sr *SendRequest) WithReceiptAdjustments(adjustments ...*ReceiptAdjustment)
 	return sr
 }
 
+// URLAction is a fluent helper method for creating an action with type "web_url" for
+// use in a message with generic template attachment.
+func URLAction(url string) *Action {
+	return &Action{
+		Type: "web_url",
+		URL:  url,
+	}
+}
+
 // URLButton is a fluent helper method for creating a button with type "web_url" for
 // use in a message with a button template or generic template attachment.
 func URLButton(title, url string) *Button {
@@ -338,6 +347,13 @@ type Button struct {
 	Payload string `json:"payload,omitempty"`
 }
 
+// Action represents a default action for element in a structured message using the generic template.
+type Action struct {
+	Type    string `json:"type" binding:"required"`
+	URL     string `json:"url,omitempty"`
+	Payload string `json:"payload,omitempty"`
+}
+
 /*
 GenericPayload is used to build a structured message using the generic template.
 
@@ -350,10 +366,11 @@ type GenericPayload struct {
 
 // GenericElement represents one item in the carousel of a generic template message.
 type GenericElement struct {
-	Title    string    `json:"title" binding:"required"`
-	ImageURL string    `json:"image_url" binding:"required"`
-	Subtitle string    `json:"subtitle" binding:"required"`
-	Buttons  []*Button `json:"buttons" binding:"required"`
+	Title         string    `json:"title" binding:"required"`
+	ImageURL      string    `json:"image_url" binding:"required"`
+	Subtitle      string    `json:"subtitle" binding:"required"`
+	DefaultAction *Action   `json:"default_action,omitempty"`
+	Buttons       []*Button `json:"buttons" binding:"required"`
 }
 
 /*

--- a/models_test.go
+++ b/models_test.go
@@ -152,6 +152,26 @@ var _ = Describe("Send API Models", func() {
 		expectCorrectMarshaling(sendRequest, "message-with-generic-template-attachment.json")
 	})
 
+	It("should marshal a send request with a generic attachment and default action", func() {
+		viewWebsite := URLButton("View Website", "https://petersapparel.parseapp.com/view_item?item_id=100")
+
+		startChatting := PostbackButton("Start Chatting", "USER_DEFINED_PAYLOAD")
+
+		urlAction := URLAction("https://petersapparel.parseapp.com/view_item?item_id=100")
+
+		welcome := &GenericElement{
+			Title:         "Welcome to Peter's Hats",
+			ImageURL:      "http://petersapparel.parseapp.com/img/item100-thumb.png",
+			Subtitle:      "We've got the right hat for everyone.",
+			DefaultAction: urlAction,
+			Buttons:       []*Button{viewWebsite, startChatting},
+		}
+
+		sendRequest := GenericTemplateMessage(welcome).To("USER_ID")
+
+		expectCorrectMarshaling(sendRequest, "message-with-generic-template-attachment-and-default-action.json")
+	})
+
 	It("should marshal a send request with a receipt attachment", func() {
 		header := &ReceiptHeader{
 			RecipientName: "Stephane Crozatier",

--- a/sample-send-api-data/message-with-generic-template-attachment-and-default-action.json
+++ b/sample-send-api-data/message-with-generic-template-attachment-and-default-action.json
@@ -1,0 +1,36 @@
+{
+  "recipient": {
+    "id": "USER_ID"
+  },
+  "message": {
+    "attachment": {
+      "type": "template",
+      "payload": {
+        "template_type": "generic",
+        "elements": [
+          {
+            "title": "Welcome to Peter's Hats",
+            "image_url": "http://petersapparel.parseapp.com/img/item100-thumb.png",
+            "subtitle": "We've got the right hat for everyone.",
+            "default_action": {
+              "type": "web_url",
+              "url": "https://petersapparel.parseapp.com/view_item?item_id=100"
+            },
+            "buttons": [
+              {
+                "type": "web_url",
+                "title": "View Website",
+                "url": "https://petersapparel.parseapp.com/view_item?item_id=100"
+              },
+              {
+                "type": "postback",
+                "title": "Start Chatting",
+                "payload": "USER_DEFINED_PAYLOAD"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Element in generic-template message allows to define option default action of _web_url_ type (see https://developers.facebook.com/docs/messenger-platform/reference/template/generic/)